### PR TITLE
Added the comment and reply for the forum and their test cases

### DIFF
--- a/src/main/java/com/ucan/backend/gateway/controller/UserCommentController.java
+++ b/src/main/java/com/ucan/backend/gateway/controller/UserCommentController.java
@@ -1,0 +1,27 @@
+package com.ucan.backend.gateway.controller;
+
+import com.ucan.backend.post.UserCommentAPI;
+import com.ucan.backend.post.UserCommentDTO;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/posts/{postId}/comments")
+@RequiredArgsConstructor
+public class UserCommentController {
+
+  private final UserCommentAPI userCommentAPI;
+
+  @PostMapping
+  public ResponseEntity<UserCommentDTO> createComment(
+      @PathVariable Long postId, @RequestBody UserCommentDTO dto) {
+    return ResponseEntity.ok(userCommentAPI.createComment(postId, dto));
+  }
+
+  @GetMapping
+  public ResponseEntity<List<UserCommentDTO>> getCommentsByPost(@PathVariable Long postId) {
+    return ResponseEntity.ok(userCommentAPI.getCommentsByPostId(postId));
+  }
+}

--- a/src/main/java/com/ucan/backend/gateway/controller/UserReplyController.java
+++ b/src/main/java/com/ucan/backend/gateway/controller/UserReplyController.java
@@ -1,0 +1,29 @@
+package com.ucan.backend.gateway.controller;
+
+import com.ucan.backend.post.UserReplyAPI;
+import com.ucan.backend.post.UserReplyDTO;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/comments/{commentId}/replies")
+@RequiredArgsConstructor
+public class UserReplyController {
+
+  private final UserReplyAPI userReplyAPI;
+
+  @PostMapping
+  public ResponseEntity<UserReplyDTO> createReply(
+      @PathVariable Long commentId, @RequestBody UserReplyDTO dto) {
+    UserReplyDTO replyToSave =
+        new UserReplyDTO(null, commentId, dto.authorId(), dto.content(), null);
+    return ResponseEntity.ok(userReplyAPI.createReply(replyToSave));
+  }
+
+  @GetMapping
+  public ResponseEntity<List<UserReplyDTO>> getReplies(@PathVariable Long commentId) {
+    return ResponseEntity.ok(userReplyAPI.getRepliesByCommentId(commentId));
+  }
+}

--- a/src/main/java/com/ucan/backend/post/UserCommentAPI.java
+++ b/src/main/java/com/ucan/backend/post/UserCommentAPI.java
@@ -1,0 +1,13 @@
+package com.ucan.backend.post;
+
+import java.util.List;
+
+public interface UserCommentAPI {
+  UserCommentDTO createComment(Long postId, UserCommentDTO dto);
+
+  List<UserCommentDTO> getCommentsByPostId(Long postId);
+
+  UserCommentDTO getCommentById(Long commentId);
+
+  boolean existsById(Long commentId);
+}

--- a/src/main/java/com/ucan/backend/post/UserCommentDTO.java
+++ b/src/main/java/com/ucan/backend/post/UserCommentDTO.java
@@ -1,0 +1,6 @@
+package com.ucan.backend.post;
+
+import java.time.Instant;
+
+public record UserCommentDTO(
+    Long id, Long postId, Long authorId, String content, int replyCount, Instant createdAt) {}

--- a/src/main/java/com/ucan/backend/post/UserReplyAPI.java
+++ b/src/main/java/com/ucan/backend/post/UserReplyAPI.java
@@ -1,0 +1,13 @@
+package com.ucan.backend.post;
+
+import java.util.List;
+
+public interface UserReplyAPI {
+  UserReplyDTO createReply(UserReplyDTO replyDTO);
+
+  List<UserReplyDTO> getRepliesByCommentId(Long commentId);
+
+  UserReplyDTO getReplyById(Long replyId);
+
+  boolean existsById(Long replyId);
+}

--- a/src/main/java/com/ucan/backend/post/UserReplyDTO.java
+++ b/src/main/java/com/ucan/backend/post/UserReplyDTO.java
@@ -1,0 +1,6 @@
+package com.ucan.backend.post;
+
+import java.time.Instant;
+
+public record UserReplyDTO(
+    Long id, Long commentId, Long authorId, String content, Instant createdAt) {}

--- a/src/main/java/com/ucan/backend/post/mapper/UserCommentMapper.java
+++ b/src/main/java/com/ucan/backend/post/mapper/UserCommentMapper.java
@@ -1,0 +1,30 @@
+package com.ucan.backend.post.mapper;
+
+import com.ucan.backend.post.UserCommentDTO;
+import com.ucan.backend.post.model.UserCommentEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserCommentMapper {
+
+  public UserCommentDTO toDTO(UserCommentEntity entity) {
+    return new UserCommentDTO(
+        entity.getId(),
+        entity.getPostId(),
+        entity.getAuthorId(),
+        entity.getContent(),
+        entity.getReplyCount(),
+        entity.getCreatedAt());
+  }
+
+  public UserCommentEntity toEntity(UserCommentDTO dto) {
+    return UserCommentEntity.builder()
+        .id(dto.id())
+        .postId(dto.postId())
+        .authorId(dto.authorId())
+        .content(dto.content())
+        .replyCount(dto.replyCount())
+        .createdAt(dto.createdAt())
+        .build();
+  }
+}

--- a/src/main/java/com/ucan/backend/post/mapper/UserReplyMapper.java
+++ b/src/main/java/com/ucan/backend/post/mapper/UserReplyMapper.java
@@ -1,0 +1,28 @@
+package com.ucan.backend.post.mapper;
+
+import com.ucan.backend.post.UserReplyDTO;
+import com.ucan.backend.post.model.UserReplyEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserReplyMapper {
+
+  public UserReplyDTO toDTO(UserReplyEntity entity) {
+    return new UserReplyDTO(
+        entity.getId(),
+        entity.getCommentId(),
+        entity.getAuthorId(),
+        entity.getContent(),
+        entity.getCreatedAt());
+  }
+
+  public UserReplyEntity toEntity(UserReplyDTO dto) {
+    return UserReplyEntity.builder()
+        .id(dto.id())
+        .commentId(dto.commentId())
+        .authorId(dto.authorId())
+        .content(dto.content())
+        .createdAt(dto.createdAt())
+        .build();
+  }
+}

--- a/src/main/java/com/ucan/backend/post/model/UserCommentEntity.java
+++ b/src/main/java/com/ucan/backend/post/model/UserCommentEntity.java
@@ -1,0 +1,37 @@
+package com.ucan.backend.post.model;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import lombok.*;
+
+@Entity
+@Table(name = "user_comments")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserCommentEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private Long postId;
+
+  @Column(nullable = false)
+  private Long authorId;
+
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String content;
+
+  private int replyCount;
+
+  private Instant createdAt;
+
+  @PrePersist
+  protected void onCreate() {
+    createdAt = Instant.now();
+  }
+}

--- a/src/main/java/com/ucan/backend/post/model/UserReplyEntity.java
+++ b/src/main/java/com/ucan/backend/post/model/UserReplyEntity.java
@@ -1,0 +1,34 @@
+package com.ucan.backend.post.model;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import lombok.*;
+
+@Entity
+@Table(name = "replies")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserReplyEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private Long commentId;
+
+  @Column(nullable = false)
+  private Long authorId;
+
+  @Column(nullable = false, length = 2000)
+  private String content;
+
+  private Instant createdAt;
+
+  @PrePersist
+  public void onCreate() {
+    this.createdAt = Instant.now();
+  }
+}

--- a/src/main/java/com/ucan/backend/post/repository/UserCommentRepository.java
+++ b/src/main/java/com/ucan/backend/post/repository/UserCommentRepository.java
@@ -1,0 +1,11 @@
+package com.ucan.backend.post.repository;
+
+import com.ucan.backend.post.model.UserCommentEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserCommentRepository extends JpaRepository<UserCommentEntity, Long> {
+  List<UserCommentEntity> findByPostId(Long postId);
+}

--- a/src/main/java/com/ucan/backend/post/repository/UserReplyRepository.java
+++ b/src/main/java/com/ucan/backend/post/repository/UserReplyRepository.java
@@ -1,0 +1,9 @@
+package com.ucan.backend.post.repository;
+
+import com.ucan.backend.post.model.UserReplyEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserReplyRepository extends JpaRepository<UserReplyEntity, Long> {
+  List<UserReplyEntity> findByCommentId(Long commentId);
+}

--- a/src/main/java/com/ucan/backend/post/service/UserCommentService.java
+++ b/src/main/java/com/ucan/backend/post/service/UserCommentService.java
@@ -1,0 +1,46 @@
+package com.ucan.backend.post.service;
+
+import com.ucan.backend.post.UserCommentAPI;
+import com.ucan.backend.post.UserCommentDTO;
+import com.ucan.backend.post.mapper.UserCommentMapper;
+import com.ucan.backend.post.model.UserCommentEntity;
+import com.ucan.backend.post.repository.UserCommentRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserCommentService implements UserCommentAPI {
+
+  private final UserCommentRepository repository;
+  private final UserCommentMapper mapper;
+
+  @Override
+  public UserCommentDTO createComment(Long postId, UserCommentDTO dto) {
+    UserCommentEntity entity = mapper.toEntity(dto);
+    entity.setPostId(postId);
+    return mapper.toDTO(repository.save(entity));
+  }
+
+  @Override
+  public List<UserCommentDTO> getCommentsByPostId(Long postId) {
+    return repository.findByPostId(postId).stream().map(mapper::toDTO).collect(Collectors.toList());
+  }
+
+  @Override
+  public UserCommentDTO getCommentById(Long commentId) {
+    return repository
+        .findById(commentId)
+        .map(mapper::toDTO)
+        .orElseThrow(() -> new IllegalArgumentException("Comment not found"));
+  }
+
+  @Override
+  public boolean existsById(Long commentId) {
+    return repository.existsById(commentId);
+  }
+}

--- a/src/main/java/com/ucan/backend/post/service/UserReplyService.java
+++ b/src/main/java/com/ucan/backend/post/service/UserReplyService.java
@@ -1,0 +1,48 @@
+package com.ucan.backend.post.service;
+
+import com.ucan.backend.post.UserReplyAPI;
+import com.ucan.backend.post.UserReplyDTO;
+import com.ucan.backend.post.mapper.UserReplyMapper;
+import com.ucan.backend.post.model.UserReplyEntity;
+import com.ucan.backend.post.repository.UserReplyRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserReplyService implements UserReplyAPI {
+
+  private final UserReplyRepository replyRepository;
+  private final UserReplyMapper replyMapper;
+
+  @Override
+  public UserReplyDTO createReply(UserReplyDTO replyDTO) {
+    UserReplyEntity entity = replyMapper.toEntity(replyDTO);
+    UserReplyEntity saved = replyRepository.save(entity);
+    return replyMapper.toDTO(saved);
+  }
+
+  @Override
+  public List<UserReplyDTO> getRepliesByCommentId(Long commentId) {
+    return replyRepository.findByCommentId(commentId).stream()
+        .map(replyMapper::toDTO)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public UserReplyDTO getReplyById(Long replyId) {
+    return replyRepository
+        .findById(replyId)
+        .map(replyMapper::toDTO)
+        .orElseThrow(() -> new IllegalArgumentException("Reply not found"));
+  }
+
+  @Override
+  public boolean existsById(Long replyId) {
+    return replyRepository.existsById(replyId);
+  }
+}

--- a/src/test/java/com/ucan/backend/post/mapper/UserCommentMapperTest.java
+++ b/src/test/java/com/ucan/backend/post/mapper/UserCommentMapperTest.java
@@ -1,0 +1,51 @@
+package com.ucan.backend.post.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ucan.backend.post.UserCommentDTO;
+import com.ucan.backend.post.model.UserCommentEntity;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+public class UserCommentMapperTest {
+
+  private final UserCommentMapper mapper = new UserCommentMapper();
+
+  @Test
+  void toDTO_ShouldMapEntityToDTO() {
+    Instant now = Instant.now();
+    UserCommentEntity entity =
+        UserCommentEntity.builder()
+            .id(1L)
+            .postId(100L)
+            .authorId(200L)
+            .content("Test comment")
+            .replyCount(2)
+            .createdAt(now)
+            .build();
+
+    UserCommentDTO dto = mapper.toDTO(entity);
+
+    assertThat(dto.id()).isEqualTo(entity.getId());
+    assertThat(dto.postId()).isEqualTo(entity.getPostId());
+    assertThat(dto.authorId()).isEqualTo(entity.getAuthorId());
+    assertThat(dto.content()).isEqualTo(entity.getContent());
+    assertThat(dto.replyCount()).isEqualTo(entity.getReplyCount());
+    assertThat(dto.createdAt()).isEqualTo(entity.getCreatedAt());
+  }
+
+  @Test
+  void toEntity_ShouldMapDTOToEntity() {
+    Instant now = Instant.now();
+    UserCommentDTO dto = new UserCommentDTO(1L, 100L, 200L, "Test comment", 2, now);
+
+    UserCommentEntity entity = mapper.toEntity(dto);
+
+    assertThat(entity.getId()).isEqualTo(dto.id());
+    assertThat(entity.getPostId()).isEqualTo(dto.postId());
+    assertThat(entity.getAuthorId()).isEqualTo(dto.authorId());
+    assertThat(entity.getContent()).isEqualTo(dto.content());
+    assertThat(entity.getReplyCount()).isEqualTo(dto.replyCount());
+    assertThat(entity.getCreatedAt()).isEqualTo(dto.createdAt());
+  }
+}

--- a/src/test/java/com/ucan/backend/post/mapper/UserReplyMapperTest.java
+++ b/src/test/java/com/ucan/backend/post/mapper/UserReplyMapperTest.java
@@ -1,0 +1,44 @@
+package com.ucan.backend.post.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ucan.backend.post.UserReplyDTO;
+import com.ucan.backend.post.model.UserReplyEntity;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+public class UserReplyMapperTest {
+
+  private final UserReplyMapper mapper = new UserReplyMapper();
+
+  @Test
+  void toDTO_ShouldMapEntityToDTO() {
+    UserReplyEntity entity =
+        UserReplyEntity.builder()
+            .id(1L)
+            .commentId(42L)
+            .authorId(100L)
+            .content("Test reply")
+            .createdAt(Instant.now())
+            .build();
+
+    UserReplyDTO dto = mapper.toDTO(entity);
+
+    assertThat(dto.id()).isEqualTo(1L);
+    assertThat(dto.commentId()).isEqualTo(42L);
+    assertThat(dto.authorId()).isEqualTo(100L);
+    assertThat(dto.content()).isEqualTo("Test reply");
+  }
+
+  @Test
+  void toEntity_ShouldMapDTOToEntity() {
+    UserReplyDTO dto = new UserReplyDTO(1L, 42L, 100L, "Test reply", Instant.now());
+
+    UserReplyEntity entity = mapper.toEntity(dto);
+
+    assertThat(entity.getId()).isEqualTo(1L);
+    assertThat(entity.getCommentId()).isEqualTo(42L);
+    assertThat(entity.getAuthorId()).isEqualTo(100L);
+    assertThat(entity.getContent()).isEqualTo("Test reply");
+  }
+}

--- a/src/test/java/com/ucan/backend/post/model/UserCommentEntityTest.java
+++ b/src/test/java/com/ucan/backend/post/model/UserCommentEntityTest.java
@@ -1,0 +1,30 @@
+package com.ucan.backend.post.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+public class UserCommentEntityTest {
+
+  @Test
+  void builder_ShouldBuildEntity() {
+    Instant now = Instant.now();
+    UserCommentEntity entity =
+        UserCommentEntity.builder()
+            .id(1L)
+            .postId(100L)
+            .authorId(200L)
+            .content("Sample comment")
+            .replyCount(3)
+            .createdAt(now)
+            .build();
+
+    assertThat(entity.getId()).isEqualTo(1L);
+    assertThat(entity.getPostId()).isEqualTo(100L);
+    assertThat(entity.getAuthorId()).isEqualTo(200L);
+    assertThat(entity.getContent()).isEqualTo("Sample comment");
+    assertThat(entity.getReplyCount()).isEqualTo(3);
+    assertThat(entity.getCreatedAt()).isEqualTo(now);
+  }
+}

--- a/src/test/java/com/ucan/backend/post/model/UserReplyEntityTest.java
+++ b/src/test/java/com/ucan/backend/post/model/UserReplyEntityTest.java
@@ -1,0 +1,36 @@
+package com.ucan.backend.post.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+public class UserReplyEntityTest {
+
+  @Test
+  void testBuilder() {
+    Instant now = Instant.now();
+    UserReplyEntity entity =
+        UserReplyEntity.builder()
+            .id(1L)
+            .commentId(42L)
+            .authorId(100L)
+            .content("Sample reply")
+            .createdAt(now)
+            .build();
+
+    assertThat(entity.getId()).isEqualTo(1L);
+    assertThat(entity.getCommentId()).isEqualTo(42L);
+    assertThat(entity.getAuthorId()).isEqualTo(100L);
+    assertThat(entity.getContent()).isEqualTo("Sample reply");
+    assertThat(entity.getCreatedAt()).isEqualTo(now);
+    ;
+  }
+
+  @Test
+  void testOnCreate() {
+    UserReplyEntity entity = new UserReplyEntity();
+    entity.onCreate();
+    assertThat(entity.getCreatedAt()).isNotNull();
+  }
+}

--- a/src/test/java/com/ucan/backend/post/repository/UserCommentRepositoryTest.java
+++ b/src/test/java/com/ucan/backend/post/repository/UserCommentRepositoryTest.java
@@ -1,0 +1,57 @@
+package com.ucan.backend.post.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ucan.backend.post.model.UserCommentEntity;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@DataJpaTest
+@Testcontainers
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class UserCommentRepositoryTest {
+
+  @Container
+  static PostgreSQLContainer<?> postgres =
+      new PostgreSQLContainer<>("postgres:latest")
+          .withDatabaseName("testdb")
+          .withUsername("user")
+          .withPassword("pass");
+
+  @BeforeAll
+  static void beforeAll() {
+    postgres.start();
+  }
+
+  @DynamicPropertySource
+  static void setProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", postgres::getJdbcUrl);
+    registry.add("spring.datasource.username", postgres::getUsername);
+    registry.add("spring.datasource.password", postgres::getPassword);
+  }
+
+  @Autowired private TestEntityManager entityManager;
+  @Autowired private UserCommentRepository repository;
+
+  @Test
+  void findByPostId_ShouldReturnComments() {
+    UserCommentEntity comment =
+        UserCommentEntity.builder().postId(100L).authorId(1L).content("Nice post").build();
+    entityManager.persist(comment);
+    entityManager.flush();
+
+    List<UserCommentEntity> comments = repository.findByPostId(100L);
+    assertThat(comments).isNotEmpty();
+    assertThat(comments.get(0).getContent()).isEqualTo("Nice post");
+  }
+}

--- a/src/test/java/com/ucan/backend/post/repository/UserReplyRepositoryTest.java
+++ b/src/test/java/com/ucan/backend/post/repository/UserReplyRepositoryTest.java
@@ -1,0 +1,58 @@
+package com.ucan.backend.post.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ucan.backend.post.model.UserReplyEntity;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@DataJpaTest
+@Testcontainers
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class UserReplyRepositoryTest {
+
+  @Container
+  static PostgreSQLContainer<?> postgres =
+      new PostgreSQLContainer<>("postgres:latest")
+          .withDatabaseName("testdb")
+          .withUsername("user")
+          .withPassword("pass");
+
+  @BeforeAll
+  static void setup() {
+    postgres.start();
+  }
+
+  @DynamicPropertySource
+  static void setDatasourceProps(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", postgres::getJdbcUrl);
+    registry.add("spring.datasource.username", postgres::getUsername);
+    registry.add("spring.datasource.password", postgres::getPassword);
+  }
+
+  @Autowired private TestEntityManager entityManager;
+  @Autowired private UserReplyRepository repository;
+
+  @Test
+  void findByCommentId_ShouldReturnReplies() {
+    UserReplyEntity reply =
+        UserReplyEntity.builder().commentId(1L).authorId(42L).content("Hello reply").build();
+
+    entityManager.persist(reply);
+    entityManager.flush();
+
+    List<UserReplyEntity> result = repository.findByCommentId(1L);
+    assertThat(result).isNotEmpty();
+    assertThat(result.get(0).getContent()).isEqualTo("Hello reply");
+  }
+}

--- a/src/test/java/com/ucan/backend/post/service/UserCommentServiceTest.java
+++ b/src/test/java/com/ucan/backend/post/service/UserCommentServiceTest.java
@@ -1,0 +1,92 @@
+package com.ucan.backend.post.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.ucan.backend.post.UserCommentDTO;
+import com.ucan.backend.post.mapper.UserCommentMapper;
+import com.ucan.backend.post.model.UserCommentEntity;
+import com.ucan.backend.post.repository.UserCommentRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class UserCommentServiceTest {
+
+  @Mock private UserCommentRepository repository;
+  @Mock private UserCommentMapper mapper;
+
+  @InjectMocks private UserCommentService service;
+
+  private UserCommentDTO dto;
+  private UserCommentEntity entity;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+
+    dto = new UserCommentDTO(1L, 100L, 200L, "Test comment", 0, Instant.now());
+
+    entity =
+        UserCommentEntity.builder()
+            .id(1L)
+            .postId(100L)
+            .authorId(200L)
+            .content("Test comment")
+            .replyCount(0)
+            .createdAt(Instant.now())
+            .build();
+  }
+
+  @Test
+  void createComment_ShouldSaveAndReturnDTO() {
+    when(mapper.toEntity(dto)).thenReturn(entity);
+    when(repository.save(entity)).thenReturn(entity);
+    when(mapper.toDTO(entity)).thenReturn(dto);
+
+    UserCommentDTO result = service.createComment(100L, dto);
+
+    assertNotNull(result);
+    verify(repository).save(entity);
+  }
+
+  @Test
+  void getCommentById_ShouldReturnDTO_WhenFound() {
+    when(repository.findById(1L)).thenReturn(Optional.of(entity));
+    when(mapper.toDTO(entity)).thenReturn(dto);
+
+    UserCommentDTO result = service.getCommentById(1L);
+
+    assertEquals(1L, result.id());
+  }
+
+  @Test
+  void getCommentById_ShouldThrow_WhenNotFound() {
+    when(repository.findById(404L)).thenReturn(Optional.empty());
+
+    assertThrows(IllegalArgumentException.class, () -> service.getCommentById(404L));
+  }
+
+  @Test
+  void existsById_ShouldReturnCorrectValue() {
+    when(repository.existsById(1L)).thenReturn(true);
+    assertTrue(service.existsById(1L));
+
+    when(repository.existsById(2L)).thenReturn(false);
+    assertFalse(service.existsById(2L));
+  }
+
+  @Test
+  void getCommentsByPostId_ShouldReturnList() {
+    when(repository.findByPostId(100L)).thenReturn(List.of(entity));
+    when(mapper.toDTO(entity)).thenReturn(dto);
+
+    List<UserCommentDTO> comments = service.getCommentsByPostId(100L);
+    assertEquals(1, comments.size());
+  }
+}

--- a/src/test/java/com/ucan/backend/post/service/UserReplyServiceTest.java
+++ b/src/test/java/com/ucan/backend/post/service/UserReplyServiceTest.java
@@ -1,0 +1,56 @@
+package com.ucan.backend.post.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.ucan.backend.post.UserReplyDTO;
+import com.ucan.backend.post.mapper.UserReplyMapper;
+import com.ucan.backend.post.model.UserReplyEntity;
+import com.ucan.backend.post.repository.UserReplyRepository;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+
+public class UserReplyServiceTest {
+
+  @Mock private UserReplyRepository repository;
+  @Mock private UserReplyMapper mapper;
+  @InjectMocks private UserReplyService service;
+
+  private UserReplyDTO dto;
+  private UserReplyEntity entity;
+
+  @BeforeEach
+  void setup() {
+    MockitoAnnotations.openMocks(this);
+
+    dto = new UserReplyDTO(1L, 99L, 42L, "Thanks!", Instant.now());
+    entity =
+        UserReplyEntity.builder().id(1L).commentId(99L).authorId(42L).content("Thanks!").build();
+  }
+
+  @Test
+  void createReply_ShouldSaveAndReturnDTO() {
+    when(mapper.toEntity(dto)).thenReturn(entity);
+    when(repository.save(entity)).thenReturn(entity);
+    when(mapper.toDTO(entity)).thenReturn(dto);
+
+    UserReplyDTO result = service.createReply(dto);
+
+    assertEquals(dto.content(), result.content());
+    verify(repository).save(entity);
+  }
+
+  @Test
+  void getRepliesByCommentId_ShouldReturnReplies() {
+    when(repository.findByCommentId(99L)).thenReturn(List.of(entity));
+    when(mapper.toDTO(entity)).thenReturn(dto);
+
+    List<UserReplyDTO> replies = service.getRepliesByCommentId(99L);
+
+    assertEquals(1, replies.size());
+    assertEquals("Thanks!", replies.get(0).content());
+  }
+}


### PR DESCRIPTION
I added the comment and reply features under the forum (post) module, in which I have created UserComment and UserReply entities, along with their services, mappers, repositories, and controllers.

Set up APIs to:
Create and fetch comments for posts.
Create and fetch replies to those comments (just one level of replies for now).
Comments and replies are stored separately, and each comment includes a replyCount in the DTO.

Also, I have added the test cases.
This should cover the major part of the post comments and replies. Please let me know if any changes are needed.