### PR TITLE
Fix cookie not being saved on browser

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,5 +7,5 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 
 # cookie stuff
-server.servlet.session.cookie.same-site=Lax
-server.servlet.session.cookie.secure=false
+server.servlet.session.cookie.same-site=None
+server.servlet.session.cookie.secure=true


### PR DESCRIPTION
Set `same-site` to `None` and set `secure` to `true` to enable the browser to save the cookie.

### Testing:
Ran frontend and backend, and confirmed that making a request to backend after logging in sends a cookie and is authorized.

### Commenting:
There is a comment, "cookie stuff", that labels these config settings.