### PR TITLE
Add badges to UserDetails and return badges when getting profile data

### DIFF
--- a/src/main/java/com/ucan/backend/config/CustomUserDetails.java
+++ b/src/main/java/com/ucan/backend/config/CustomUserDetails.java
@@ -1,7 +1,9 @@
 package com.ucan.backend.config;
 
+import com.ucan.backend.userauth.BadgeDTO;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -14,13 +16,16 @@ public class CustomUserDetails implements UserDetails {
   private final String password;
   private final boolean enabled;
   private final Collection<? extends GrantedAuthority> authorities;
+  private final List<BadgeDTO> badges;
 
-  public CustomUserDetails(Long userId, String username, String password, boolean enabled) {
+  public CustomUserDetails(
+      Long userId, String username, String password, boolean enabled, List<BadgeDTO> badges) {
     this.userId = userId;
     this.username = username;
     this.password = password;
     this.enabled = enabled;
     this.authorities = Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+    this.badges = badges;
   }
 
   @Override

--- a/src/main/java/com/ucan/backend/config/SecurityConfig.java
+++ b/src/main/java/com/ucan/backend/config/SecurityConfig.java
@@ -33,7 +33,11 @@ public class SecurityConfig {
         throw new UsernameNotFoundException("User not found with username: " + username);
       }
       return new CustomUserDetails(
-          userDTO.id(), userDTO.username(), userDTO.password(), userDTO.enabled());
+          userDTO.id(),
+          userDTO.username(),
+          userDTO.password(),
+          userDTO.enabled(),
+          userDTO.badges());
     };
   }
 

--- a/src/main/java/com/ucan/backend/gateway/controller/UserProfileController.java
+++ b/src/main/java/com/ucan/backend/gateway/controller/UserProfileController.java
@@ -1,5 +1,8 @@
 package com.ucan.backend.gateway.controller;
 
+import com.ucan.backend.gateway.dto.userprofile.ProfileResponse;
+import com.ucan.backend.userauth.UserAuthAPI;
+import com.ucan.backend.userauth.UserAuthDTO;
 import com.ucan.backend.userprofile.UserProfileAPI;
 import com.ucan.backend.userprofile.UserProfileDTO;
 import lombok.RequiredArgsConstructor;
@@ -12,14 +15,35 @@ import org.springframework.web.bind.annotation.*;
 public class UserProfileController {
 
   private final UserProfileAPI profileAPI;
+  private final UserAuthAPI authAPI;
 
   @PostMapping
   public ResponseEntity<UserProfileDTO> createOrUpdate(@RequestBody UserProfileDTO dto) {
     return ResponseEntity.ok(profileAPI.createOrUpdateProfile(dto));
   }
 
+  /**
+   * Retrieves a user's profile information by their user ID. This endpoint combines profile data
+   * from both the user profile and authentication services to provide a complete profile view.
+   *
+   * @param userId The unique identifier of the user whose profile is being requested
+   * @return ResponseEntity containing a ProfileResponse with the user's complete profile
+   *     information
+   * @throws IllegalArgumentException if the user profile is not found
+   */
   @GetMapping("/{userId}")
-  public ResponseEntity<UserProfileDTO> getByUserId(@PathVariable Long userId) {
-    return ResponseEntity.ok(profileAPI.getByUserId(userId));
+  public ResponseEntity<ProfileResponse> getByUserId(@PathVariable Long userId) {
+    UserProfileDTO profileDTO = profileAPI.getByUserId(userId);
+    UserAuthDTO authDTO = authAPI.findByUsername(profileDTO.fullName());
+    ProfileResponse profileResponse =
+        new ProfileResponse(
+            profileDTO.userId(),
+            profileDTO.fullName(),
+            profileDTO.linkedinUrl(),
+            profileDTO.personalWebsite(),
+            profileDTO.bio(),
+            profileDTO.graduationYear(),
+            authDTO.badges());
+    return ResponseEntity.ok(profileResponse);
   }
 }

--- a/src/main/java/com/ucan/backend/gateway/dto/userprofile/ProfileResponse.java
+++ b/src/main/java/com/ucan/backend/gateway/dto/userprofile/ProfileResponse.java
@@ -1,0 +1,13 @@
+package com.ucan.backend.gateway.dto.userprofile;
+
+import com.ucan.backend.userauth.BadgeDTO;
+import java.util.List;
+
+public record ProfileResponse(
+    Long userId,
+    String fullName,
+    String linkedinUrl,
+    String personalWebsite,
+    String bio,
+    Integer graduationYear,
+    List<BadgeDTO> badges) {}

--- a/src/test/java/com/ucan/backend/gateway/controller/UserProfileControllerTest.java
+++ b/src/test/java/com/ucan/backend/gateway/controller/UserProfileControllerTest.java
@@ -1,0 +1,119 @@
+package com.ucan.backend.gateway.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.ucan.backend.gateway.dto.userprofile.ProfileResponse;
+import com.ucan.backend.userauth.BadgeDTO;
+import com.ucan.backend.userauth.UserAuthAPI;
+import com.ucan.backend.userauth.UserAuthDTO;
+import com.ucan.backend.userprofile.UserProfileAPI;
+import com.ucan.backend.userprofile.UserProfileDTO;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class UserProfileControllerTest {
+
+  @Mock private UserProfileAPI profileAPI;
+  @Mock private UserAuthAPI authAPI;
+
+  @InjectMocks private UserProfileController controller;
+
+  private UserProfileDTO profileDTO;
+  private UserAuthDTO authDTO;
+  private ProfileResponse expectedResponse;
+
+  @BeforeEach
+  void setUp() {
+    profileDTO =
+        new UserProfileDTO(
+            1L,
+            42L,
+            "John Doe",
+            "https://linkedin.com/in/johndoe",
+            "https://johndoe.dev",
+            "Software Engineer",
+            2025,
+            List.of("UW"),
+            null,
+            null);
+
+    authDTO =
+        new UserAuthDTO(
+            42L,
+            "John Doe",
+            "john@example.com",
+            "password",
+            true,
+            List.of(new BadgeDTO("UW", false), new BadgeDTO("Google", false)));
+
+    expectedResponse =
+        new ProfileResponse(
+            profileDTO.userId(),
+            profileDTO.fullName(),
+            profileDTO.linkedinUrl(),
+            profileDTO.personalWebsite(),
+            profileDTO.bio(),
+            profileDTO.graduationYear(),
+            authDTO.badges());
+  }
+
+  @Test
+  void getByUserId_Success() {
+    // Arrange
+    when(profileAPI.getByUserId(42L)).thenReturn(profileDTO);
+    when(authAPI.findByUsername(profileDTO.fullName())).thenReturn(authDTO);
+
+    // Act
+    ResponseEntity<ProfileResponse> response = controller.getByUserId(42L);
+
+    // Assert
+    assertNotNull(response);
+    assertEquals(200, response.getStatusCode().value());
+    assertNotNull(response.getBody());
+
+    ProfileResponse actualResponse = response.getBody();
+    assertEquals(expectedResponse.userId(), actualResponse.userId());
+    assertEquals(expectedResponse.fullName(), actualResponse.fullName());
+    assertEquals(expectedResponse.linkedinUrl(), actualResponse.linkedinUrl());
+    assertEquals(expectedResponse.personalWebsite(), actualResponse.personalWebsite());
+    assertEquals(expectedResponse.bio(), actualResponse.bio());
+    assertEquals(expectedResponse.graduationYear(), actualResponse.graduationYear());
+    assertEquals(expectedResponse.badges(), actualResponse.badges());
+
+    // Verify interactions
+    verify(profileAPI).getByUserId(42L);
+    verify(authAPI).findByUsername(profileDTO.fullName());
+  }
+
+  @Test
+  void getByUserId_ProfileNotFound() {
+    // Arrange
+    when(profileAPI.getByUserId(999L)).thenThrow(new IllegalArgumentException("Profile not found"));
+
+    // Act & Assert
+    assertThrows(IllegalArgumentException.class, () -> controller.getByUserId(999L));
+    verify(profileAPI).getByUserId(999L);
+    verify(authAPI, never()).findByUsername(anyString());
+  }
+
+  @Test
+  void getByUserId_AuthNotFound() {
+    // Arrange
+    when(profileAPI.getByUserId(42L)).thenReturn(profileDTO);
+    when(authAPI.findByUsername(profileDTO.fullName()))
+        .thenThrow(new IllegalArgumentException("User not found"));
+
+    // Act & Assert
+    assertThrows(IllegalArgumentException.class, () -> controller.getByUserId(42L));
+    verify(profileAPI).getByUserId(42L);
+    verify(authAPI).findByUsername(profileDTO.fullName());
+  }
+}


### PR DESCRIPTION
Properly added badge data to GET /profile/{userId}. Also added badge data to CustomUserDetails. Currently, when a new badge is created or verified, the CustomUserDetails session will still reflect the old data, so the user needs to log out and log back in to refresh the session to get the new data. In the future, we should programmatically refresh the session whenever badge data changes. 

### Testing
- Unit tests for `getByUserId` in `src/test/java/com/ucan/backend/gateway/controller/UserProfileControllerTest.java`
- Also manually tested integration with Postman

### Commenting
- Added API comments for `getByUserId` in `src/main/java/com/ucan/backend/gateway/controller/UserProfileController.java`