### PR TITLE
Added more endpoints to cookie whitelist

### DIFF
--- a/src/main/java/com/ucan/backend/config/CorsConfig.java
+++ b/src/main/java/com/ucan/backend/config/CorsConfig.java
@@ -16,7 +16,7 @@ public class CorsConfig {
         registry
             .addMapping("/**") // Apply to all endpoints
             .allowedOrigins("http://localhost:3000") // Allow requests from the frontend
-            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS") // Allow these HTTP methods
+            .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS") // Allow these HTTP methods
             .allowedHeaders("*") // Allow all headers
             .allowCredentials(true); // Allow cookies/sessions
       }

--- a/src/main/java/com/ucan/backend/config/CorsConfig.java
+++ b/src/main/java/com/ucan/backend/config/CorsConfig.java
@@ -16,7 +16,8 @@ public class CorsConfig {
         registry
             .addMapping("/**") // Apply to all endpoints
             .allowedOrigins("http://localhost:3000") // Allow requests from the frontend
-            .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS") // Allow these HTTP methods
+            .allowedMethods(
+                "GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS") // Allow these HTTP methods
             .allowedHeaders("*") // Allow all headers
             .allowCredentials(true); // Allow cookies/sessions
       }

--- a/src/main/java/com/ucan/backend/config/SecurityConfig.java
+++ b/src/main/java/com/ucan/backend/config/SecurityConfig.java
@@ -59,7 +59,11 @@ public class SecurityConfig {
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http.authorizeHttpRequests(
             request ->
-                request.requestMatchers("/api/auth/**").permitAll().anyRequest().authenticated())
+                request.requestMatchers("/api/auth/**").permitAll()
+                .requestMatchers("/api/posts/**").permitAll()
+                .requestMatchers("/posts/*/comments").permitAll()
+                .requestMatchers("/comments/*/replies").permitAll()
+                .requestMatchers("/profile/*").permitAll().anyRequest().authenticated())
         .formLogin(form -> form.disable())
         .logout(logout -> logout.permitAll())
         .csrf((csrf) -> csrf.disable())

--- a/src/main/java/com/ucan/backend/config/SecurityConfig.java
+++ b/src/main/java/com/ucan/backend/config/SecurityConfig.java
@@ -59,11 +59,19 @@ public class SecurityConfig {
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http.authorizeHttpRequests(
             request ->
-                request.requestMatchers("/api/auth/**").permitAll()
-                .requestMatchers("/api/posts/**").permitAll()
-                .requestMatchers("/posts/*/comments").permitAll()
-                .requestMatchers("/comments/*/replies").permitAll()
-                .requestMatchers("/profile/*").permitAll().anyRequest().authenticated())
+                request
+                    .requestMatchers("/api/auth/**")
+                    .permitAll()
+                    .requestMatchers("/api/posts/**")
+                    .permitAll()
+                    .requestMatchers("/posts/*/comments")
+                    .permitAll()
+                    .requestMatchers("/comments/*/replies")
+                    .permitAll()
+                    .requestMatchers("/profile/*")
+                    .permitAll()
+                    .anyRequest()
+                    .authenticated())
         .formLogin(form -> form.disable())
         .logout(logout -> logout.permitAll())
         .csrf((csrf) -> csrf.disable())


### PR DESCRIPTION
The following endpoints had to be publicly available so users that aren't logged in can still be able to browse the forum and posts, which is why I whitelisted them in SecurityConfig.java:
- `/api/posts/**` so posts can be fetched and displayed for everyone
- `/posts/*/comments` so comments associated with posts can be fetched and displayed when viewing posts
- `/comments/*/replies` so replies associated with comments can be fetched and displayed when viewing posts
- `/profile/*` so profile names can be fetched and rendered onto posts for those who aren't logged in

Also added `"PATCH"` to list of allowed http methods in CorsConfig.java since upvotePost and downvotePost are called with `api.patch` in frontend.