### PR TITLE
Vote toggle logic for posts (upvote/downvote) and related tests

### DIFF
--- a/src/main/java/com/ucan/backend/gateway/controller/UserPostController.java
+++ b/src/main/java/com/ucan/backend/gateway/controller/UserPostController.java
@@ -48,17 +48,17 @@ public class UserPostController {
     return ResponseEntity.ok(postService.updatePost(postId, title, description));
   }
 
-  // endpoint to allow users to upvote a post by its ID
+  // It toggles upvote for a post. If user already upvoted, remove it
   @PatchMapping("/{postId}/upvote")
-  public ResponseEntity<Void> upvotePost(@PathVariable Long postId) {
-    postService.upvotePost(postId);
+  public ResponseEntity<Void> upvotePost(@PathVariable Long postId, @RequestParam Long userId) {
+    postService.upvotePost(postId, userId);
     return ResponseEntity.ok().build();
   }
 
-  // endpoint to allow users to downvote a post by its ID
+  // It toggles downvote for a post. If user already downvoted, remove it
   @PatchMapping("/{postId}/downvote")
-  public ResponseEntity<Void> downvotePost(@PathVariable Long postId) {
-    postService.downvotePost(postId);
+  public ResponseEntity<Void> downvotePost(@PathVariable Long postId, @RequestParam Long userId) {
+    postService.downvotePost(postId, userId);
     return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/ucan/backend/post/UserPostAPI.java
+++ b/src/main/java/com/ucan/backend/post/UserPostAPI.java
@@ -20,7 +20,7 @@ public interface UserPostAPI {
   List<UserPostDTO> getPostsByTag(String tag);
 
   // upvotePost and downvotePost to the public API interface for modular access
-  void upvotePost(Long postId);
+  void upvotePost(Long postId, Long userId);
 
-  void downvotePost(Long postId);
+  void downvotePost(Long postId, Long userId);
 }

--- a/src/main/java/com/ucan/backend/post/model/UserPostEntity.java
+++ b/src/main/java/com/ucan/backend/post/model/UserPostEntity.java
@@ -2,6 +2,8 @@ package com.ucan.backend.post.model;
 
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
@@ -24,6 +26,12 @@ public class UserPostEntity {
 
   @Column(nullable = false)
   private int downvote = 0;
+
+  @ElementCollection(fetch = FetchType.EAGER)
+  @CollectionTable(name = "user_post_votes", joinColumns = @JoinColumn(name = "post_id"))
+  @MapKeyColumn(name = "user_id")
+  @Column(name = "vote", columnDefinition = "boolean") // true for upvote and false for downvote
+  private Map<Long, Boolean> userVotes = new HashMap<>();
 
   @Column(length = 1000)
   private String description;


### PR DESCRIPTION
Updated upvote and downvote functionality by enforcing a one-vote-per-user limit on posts. This allows users to toggle or switch their votes. Changes are made in UserPostEntity, UserPostService, and related files.
Votes are stored in a Map<Long, Boolean> field (userVotes), which handles toggling and switching between upvote/downvote.

Tests:
- Added unit tests in UserPostServiceTest to cover:
- Adding a new upvote/downvote
- Removing an existing vote
- Switching from upvote to downvote and vice versa
- Handling missing posts gracefully

Also updated UserPostDTO and UserPostMapper to include the userVotes map, and adjusted existing tests to work with the new logic.