### PR TITLE
Send email when account created or badge made

### DIFF
--- a/src/main/java/com/ucan/backend/config/SecurityConfig.java
+++ b/src/main/java/com/ucan/backend/config/SecurityConfig.java
@@ -60,6 +60,8 @@ public class SecurityConfig {
     http.authorizeHttpRequests(
             request ->
                 request
+                    .requestMatchers("/api/auth/badge")
+                    .authenticated()
                     .requestMatchers("/api/auth/**")
                     .permitAll()
                     .requestMatchers("/api/posts/**")

--- a/src/main/java/com/ucan/backend/gateway/controller/UserAuthController.java
+++ b/src/main/java/com/ucan/backend/gateway/controller/UserAuthController.java
@@ -18,11 +18,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -69,7 +65,7 @@ public class UserAuthController {
       CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
       return ResponseEntity.ok(userDetails.getUserId());
     } catch (Exception e) {
-      return ResponseEntity.badRequest().body(new ErrorResponse("Invalid username or password"));
+      return ResponseEntity.badRequest().body(new ErrorResponse("Invalid username or password, or email not verified"));
     }
   }
 
@@ -86,7 +82,7 @@ public class UserAuthController {
       CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
       Long userId = userDetails.getUserId();
 
-      BadgeDTO badgeDTO = new BadgeDTO(request.organizationName().toUpperCase(), false);
+      BadgeDTO badgeDTO = new BadgeDTO(request.organizationName(), false);
       userAuthService.addBadge(userId, badgeDTO);
       return ResponseEntity.ok().build();
     } catch (Exception e) {
@@ -101,8 +97,28 @@ public class UserAuthController {
       CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
       Long userId = userDetails.getUserId();
 
-      BadgeDTO badgeDTO = new BadgeDTO(request.organizationName().toUpperCase(), false);
+      BadgeDTO badgeDTO = new BadgeDTO(request.organizationName(), false);
       userAuthService.removeBadge(userId, badgeDTO);
+      return ResponseEntity.ok().build();
+    } catch (Exception e) {
+      return ResponseEntity.badRequest().body(new ErrorResponse(e.getMessage()));
+    }
+  }
+
+  @GetMapping("/verify/user")
+  public ResponseEntity<?> verifyUser(@RequestParam String token) {
+    try {
+      userAuthService.verifyUser(token);
+      return ResponseEntity.ok().build();
+    } catch (Exception e) {
+      return ResponseEntity.badRequest().body(new ErrorResponse(e.getMessage()));
+    }
+  }
+
+  @GetMapping("/verify/badge")
+  public ResponseEntity<?> verifyBadge(@RequestParam String token) {
+    try {
+      userAuthService.verifyBadge(token);
       return ResponseEntity.ok().build();
     } catch (Exception e) {
       return ResponseEntity.badRequest().body(new ErrorResponse(e.getMessage()));

--- a/src/main/java/com/ucan/backend/gateway/controller/UserProfileController.java
+++ b/src/main/java/com/ucan/backend/gateway/controller/UserProfileController.java
@@ -43,6 +43,7 @@ public class UserProfileController {
             profileDTO.personalWebsite(),
             profileDTO.bio(),
             profileDTO.graduationYear(),
+            authDTO.enabled(),
             authDTO.badges());
     return ResponseEntity.ok(profileResponse);
   }

--- a/src/main/java/com/ucan/backend/gateway/dto/userprofile/ProfileResponse.java
+++ b/src/main/java/com/ucan/backend/gateway/dto/userprofile/ProfileResponse.java
@@ -10,4 +10,5 @@ public record ProfileResponse(
     String personalWebsite,
     String bio,
     Integer graduationYear,
+    boolean verified,
     List<BadgeDTO> badges) {}

--- a/src/main/java/com/ucan/backend/userauth/UserAuthAPI.java
+++ b/src/main/java/com/ucan/backend/userauth/UserAuthAPI.java
@@ -14,4 +14,8 @@ public interface UserAuthAPI {
   void addBadge(Long userId, BadgeDTO badgeDTO);
 
   void removeBadge(Long userId, BadgeDTO badgeDTO);
+
+  void verifyUser(String token);
+
+  void verifyBadge(String token);
 }

--- a/src/main/java/com/ucan/backend/userauth/repository/UserAuthRepository.java
+++ b/src/main/java/com/ucan/backend/userauth/repository/UserAuthRepository.java
@@ -27,4 +27,9 @@ public interface UserAuthRepository extends JpaRepository<UserAuthEntity, Long> 
       "SELECT CASE WHEN COUNT(b) > 0 THEN true ELSE false END FROM BadgeEntity b WHERE b.id.userId = :userId AND b.id.organizationName = :organizationName")
   boolean existsBadgeByUserIdAndOrganization(
       @Param("userId") Long userId, @Param("organizationName") String organizationName);
+
+  @Query(
+      "SELECT b FROM BadgeEntity b WHERE b.id.organizationName = :organizationName AND b.validated = false")
+  Optional<BadgeEntity> findBadgeByOrganizationName(
+      @Param("organizationName") String organizationName);
 }

--- a/src/main/java/com/ucan/backend/userauth/service/EmailService.java
+++ b/src/main/java/com/ucan/backend/userauth/service/EmailService.java
@@ -1,0 +1,39 @@
+package com.ucan.backend.userauth.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+  @Value("${MAIL_ENDPOINT_URL}")
+  private String mailEndpointUrl;
+
+  private final JavaMailSender mailSender;
+
+  public void sendVerificationEmail(String to, String token, String type)
+      throws MessagingException {
+    MimeMessage message = mailSender.createMimeMessage();
+    MimeMessageHelper helper = new MimeMessageHelper(message, true);
+
+    String subject = type.equals("USER") ? "Verify Your Account" : "Verify Your Badge";
+    String verificationUrl =
+        mailEndpointUrl + "/api/auth/verify/" + type.toLowerCase() + "?token=" + token;
+    String content =
+        String.format(
+            "Please click the following link to verify your %s: %s",
+            type.equals("USER") ? "account" : "badge", verificationUrl);
+
+    helper.setTo(to);
+    helper.setSubject(subject);
+    helper.setText(content);
+
+    mailSender.send(message);
+  }
+}

--- a/src/main/java/com/ucan/backend/userauth/service/TokenService.java
+++ b/src/main/java/com/ucan/backend/userauth/service/TokenService.java
@@ -1,0 +1,27 @@
+package com.ucan.backend.userauth.service;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TokenService {
+  private final Map<String, TokenData> tokenStore = new ConcurrentHashMap<>();
+  private final SecureRandom secureRandom = new SecureRandom();
+
+  public String generateToken(String email, String type) {
+    byte[] randomBytes = new byte[32];
+    secureRandom.nextBytes(randomBytes);
+    String token = Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes);
+    tokenStore.put(token, new TokenData(email, type));
+    return token;
+  }
+
+  public TokenData validateAndRemoveToken(String token) {
+    return tokenStore.remove(token);
+  }
+
+  public record TokenData(String email, String type) {}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,3 +22,12 @@ spring.servlet.multipart.max-request-size=10MB
 # cookie stuff
 server.servlet.session.cookie.same-site=None
 server.servlet.session.cookie.secure=true
+
+# Email Configuration
+MAIL_ENDPOINT_URL=http://localhost:8080
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=no.reply.ucan.app@gmail.com
+spring.mail.password=test
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true


### PR DESCRIPTION
- A user cannot log in to an account until its email is verified
- `spring.mail.password` in `application.properties` should be set to the email's app password
- organizationName in a POST/DELETE /api/auth/badge request should be a full email